### PR TITLE
add post-deploy to set PATH to mongodb binaries

### DIFF
--- a/jobs/mms-automation-agent/spec
+++ b/jobs/mms-automation-agent/spec
@@ -7,6 +7,7 @@ packages:
 
 templates:
   bin/mms-automation-agent_ctl: bin/mms-automation-agent_ctl
+  bin/post-deploy.erb: bin/post-deploy
   bin/monit_debugger: bin/monit_debugger
   bin/set_fqdn: bin/set_fqdn
   bin/register_consul_service: bin/register_consul_service

--- a/jobs/mms-automation-agent/templates/bin/post-deploy.erb
+++ b/jobs/mms-automation-agent/templates/bin/post-deploy.erb
@@ -4,4 +4,6 @@ set -e # exit immediately if a simple command exits with a non-zero status
 set -u # report the usage of uninitialized variables
 
 # add the (latest and greatest installed) mongodb binaries to the $PATH for all users (for convenience of the operators)
-echo -e "#!/bin/bash\nexport PATH=$(dirname $(ls -1v /var/vcap/store/mongodb-mms-automation/mongodb-linux-*/bin/mongo)):\${PATH}" > /etc/profile.d/mongodb.sh
+# since several versions might be installed, we use `ls -1v <globbed path> | tail -n1` to get the latest version
+# additionally, empty `mongodb-linux-*` folders can be left behind, therefore globbing the folder isn't enough, but we need to glob for `mongodb-linux-*/bin/mongo`
+echo -e "#!/bin/bash\nexport PATH=$(dirname $(ls -1v /var/vcap/store/mongodb-mms-automation/mongodb-linux-*/bin/mongo | tail -n1)):\${PATH}" > /etc/profile.d/mongodb.sh

--- a/jobs/mms-automation-agent/templates/bin/post-deploy.erb
+++ b/jobs/mms-automation-agent/templates/bin/post-deploy.erb
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e # exit immediately if a simple command exits with a non-zero status
+set -u # report the usage of uninitialized variables
+
+# add the (latest and greatest installed) mongodb binaries to the $PATH for all users (for convenience of the operators)
+echo -e "#!/bin/bash\nexport PATH=$(dirname $(ls -1v /var/vcap/store/mongodb-mms-automation/mongodb-linux-*/bin/mongo)):\${PATH}" > /etc/profile.d/mongodb.sh


### PR DESCRIPTION
Adding the mongodb binaries to the PATH via /etc/profile.d purely for operator convenience.