### PR TITLE
Improve PATH-setting code

### DIFF
--- a/jobs/mms-automation-agent/templates/bin/post-deploy.erb
+++ b/jobs/mms-automation-agent/templates/bin/post-deploy.erb
@@ -6,6 +6,5 @@ set -u # report the usage of uninitialized variables
 # add the (latest and greatest installed) mongodb binaries to the $PATH for all users (for convenience of the operators)
 # since several versions might be installed, we use `ls -1v <globbed path> | tail -n1` to get the latest version
 # additionally, empty `mongodb-linux-*` folders can be left behind, therefore globbing the folder isn't enough, but we need to glob for `mongodb-linux-*/bin/mongo`
-# but first, wait up to 300s for the automation agent to install mongodb in case of a fresh deployment
-timeout 300 bash -c -- "until ls /var/vcap/store/mongodb-mms-automation/mongodb-linux-* &> /dev/null; do sleep 1; done" && \
-echo -e "#!/bin/bash\nexport PATH=$(dirname $(ls -1v /var/vcap/store/mongodb-mms-automation/mongodb-linux-*/bin/mongo | tail -n1)):\${PATH}" > /etc/profile.d/mongodb.sh
+echo '#!/bin/bash' > /etc/profile.d/mongodb.sh
+echo 'export PATH="$(dirname $(ls -1v /var/vcap/store/mongodb-mms-automation/mongodb-linux-*/bin/mongo | tail -n1)):${PATH}" &> /dev/null' >> /etc/profile.d/mongodb.sh


### PR DESCRIPTION
Cleaner code that also works much more reliably and doesn't unnecessarily slow down deployments.

Instead of rendering the path we're going to prepend PATH with at deploy time, we do it at the time the user opens bash. This has the added benefit of PATH always being up to date, rather than referencing the path that was "latest and greatest" at deployment time.