### PR TITLE
Replace legacy mongo shell with mongosh

### DIFF
--- a/jobs/mms-automation-agent/spec
+++ b/jobs/mms-automation-agent/spec
@@ -61,15 +61,15 @@ properties:
     default: true
 
   mongodb.health.user:
-    description: Pre-provisioned user that is allowed to access rs.status() over the mongo cli.
+    description: Pre-provisioned user that is allowed to access rs.status() over the mongosh cli.
   mongodb.health.password:
     description: Password for the pre-provisioned user.
   mongodb.port:
     desctiption: Port of mongodb instance.
     default: 27017
   mongodb.bin_path:
-    description: Path to mongo cli binary.
-    default: /var/vcap/store/mms-automation-agent/bin/
+    description: Path to mongodb binaries.
+    default: /var/vcap/store/mongodb-mms-automation/bin/
 
   mongodb.tuning:
     description: enable mongodb kernel tuning

--- a/jobs/mms-automation-agent/templates/bin/drain
+++ b/jobs/mms-automation-agent/templates/bin/drain
@@ -9,13 +9,15 @@ do
   export PATH=${package_bin_dir}:$PATH
 done
 
-export PATH=$PATH:<%= p('mongodb.bin_path') %>
+export PATH=$PATH:<%= p('mongodb.bin_path') %> #Path to mongodb binaries
+export PATH="$PATH:$(dirname "$(ls -1v /var/vcap/store/mongodb-mms-automation/mongosh-linux-*/bin/mongosh | tail -n1)")" #Path to mongosh shell binaries
+
 
 MONGOD_PROCS=`pgrep -f "mongod -f"`
 MONGOS_PROCS=`pgrep -f "mongos -f"`  
 if [ -n "$MONGOD_PROCS" ]; then
 
-  command -v mongo >/dev/null 2>&1 || { echo "mongo could not be found. please check mongodb.bin_path. Aborting." >&2; exit 1; }
+  command -v mongosh >/dev/null 2>&1 || { echo "mongosh could not be found. please check path. Aborting." >&2; exit 1; }
 
   ruby /var/vcap/jobs/mms-automation-agent/bin/drain.rb 2>&1 >> /var/vcap/sys/log/mms-automation-agent/drain.log
 
@@ -23,7 +25,7 @@ fi
 if [ -n "$MONGOS_PROCS" ]; then
 
 	 /var/vcap/bosh/bin/monit stop mms-automation-agent
-	 pkill mongo
+	 pkill mongosh
 
 fi
 

--- a/jobs/mms-automation-agent/templates/bin/drain.rb
+++ b/jobs/mms-automation-agent/templates/bin/drain.rb
@@ -3,7 +3,7 @@ require 'json'
 
 def cluster_healty?
 
-  str = `mongo localhost:<%= p('mongodb.port') %>/admin -u <%= p('mongodb.health.user') %> -p '<%= p('mongodb.health.password') %>' --eval 'JSON.stringify(rs.status())' --quiet`
+  str = `mongosh localhost:<%= p('mongodb.port') %>/admin -u <%= p('mongodb.health.user') %> -p '<%= p('mongodb.health.password') %>' --eval 'JSON.stringify(rs.status())' --quiet`
   puts str
 
   parsed = JSON.parse(str)
@@ -11,7 +11,7 @@ def cluster_healty?
   if parsed['errmsg'] == 'not running with --replSet'
     puts 'not in cluster mode, proceeding'
     `/var/vcap/bosh/bin/monit stop mms-automation-agent`
-    `pkill mongo`
+    `pkill mongosh`
     exit 0
   end
 
@@ -34,7 +34,7 @@ while i < 60 do
   if cluster_healty?
     puts 'cluster OK, proceeding'
     
-    str = `mongo localhost:<%= p('mongodb.port') %>/admin -u <%= p('mongodb.health.user') %> -p '<%= p('mongodb.health.password') %>' --eval 'JSON.stringify(db.isMaster())' --quiet`
+    str = `mongosh localhost:<%= p('mongodb.port') %>/admin -u <%= p('mongodb.health.user') %> -p '<%= p('mongodb.health.password') %>' --eval 'JSON.stringify(db.isMaster())' --quiet`
     puts str
 
     parsed = JSON.parse(str)
@@ -42,13 +42,13 @@ while i < 60 do
 
     if parsed['ismaster'] == true
       puts 'node is writeable, doing rs.stepDown now'
-      `mongo localhost:<%= p('mongodb.port') %>/admin -u <%= p('mongodb.health.user') %> -p '<%= p('mongodb.health.password') %>' --eval 'JSON.stringify(rs.stepDown())' --quiet`
+      `mongosh localhost:<%= p('mongodb.port') %>/admin -u <%= p('mongodb.health.user') %> -p '<%= p('mongodb.health.password') %>' --eval 'JSON.stringify(rs.stepDown())' --quiet`
     end
 
-    `mongo localhost:<%= p('mongodb.port') %>/admin -u <%= p('mongodb.health.user') %> -p '<%= p('mongodb.health.password') %>' --eval 'JSON.stringify(db.shutdownServer())' --quiet`
+    `mongosh localhost:<%= p('mongodb.port') %>/admin -u <%= p('mongodb.health.user') %> -p '<%= p('mongodb.health.password') %>' --eval 'JSON.stringify(db.shutdownServer())' --quiet`
 
     `/var/vcap/bosh/bin/monit stop mms-automation-agent`
-    `pkill mongo`
+    `pkill mongosh`
     exit 0
   else
     puts 'cluster unhealty; wait and try again. try: ' + i.to_s

--- a/jobs/mms-automation-agent/templates/bin/post-deploy.erb
+++ b/jobs/mms-automation-agent/templates/bin/post-deploy.erb
@@ -3,8 +3,9 @@
 set -e # exit immediately if a simple command exits with a non-zero status
 set -u # report the usage of uninitialized variables
 
-# add the (latest and greatest installed) mongodb binaries to the $PATH for all users (for convenience of the operators)
+# add the (latest and greatest installed) mongodb and mongosh binaries to the $PATH for all users (for convenience of the operators)
 # since several versions might be installed, we use `ls -1v <globbed path> | tail -n1` to get the latest version
 # additionally, empty `mongodb-linux-*` folders can be left behind, therefore globbing the folder isn't enough, but we need to glob for `mongodb-linux-*/bin/mongo`
 echo '#!/bin/bash' > /etc/profile.d/mongodb.sh
-echo 'export PATH="$(dirname $(ls -1v /var/vcap/store/mongodb-mms-automation/mongodb-linux-*/bin/mongo | tail -n1)):${PATH}" &> /dev/null' >> /etc/profile.d/mongodb.sh
+echo 'export PATH="$(dirname $(ls -1v /var/vcap/store/mongodb-mms-automation/mongodb-linux-*/bin/mongod | tail -n1)):${PATH}" &> /dev/null' >> /etc/profile.d/mongodb.sh
+echo 'export PATH="$(dirname $(ls -1v /var/vcap/store/mongodb-mms-automation/mongosh-linux-*/bin/mongosh | tail -n1)):${PATH}" &> /dev/null' >> /etc/profile.d/mongodb.sh

--- a/jobs/mms-automation-agent/templates/bin/post-start
+++ b/jobs/mms-automation-agent/templates/bin/post-start
@@ -11,7 +11,8 @@ do
   export PATH=${package_bin_dir}:$PATH
 done
 
-export PATH=$PATH:<%= p('mongodb.bin_path') %>
+export PATH=$PATH:<%= p('mongodb.bin_path') %> #Path to mongodb binaries
+export PATH="$PATH:$(dirname "$(ls -1v /var/vcap/store/mongodb-mms-automation/mongosh-linux-*/bin/mongosh | tail -n1)")" #Path to mongosh shell binaries
 
 /var/vcap/jobs/mms-automation-agent/bin/enable_telegraf_plugin
 

--- a/jobs/mms-automation-agent/templates/bin/post-start.rb
+++ b/jobs/mms-automation-agent/templates/bin/post-start.rb
@@ -11,7 +11,7 @@ timeOutTime = startTime + timeOut
 def get_rs_state
   begin
 
-    str = `mongo localhost:<%= p('mongodb.port') %>/admin -u <%= p('mongodb.health.user') %> -p '<%= p('mongodb.health.password') %>' --eval 'JSON.stringify(rs.status())' --quiet`
+    str = `mongosh localhost:<%= p('mongodb.port') %>/admin -u <%= p('mongodb.health.user') %> -p '<%= p('mongodb.health.password') %>' --eval 'JSON.stringify(rs.status())' --quiet`
 
     # Raise Error if status code is not 0s
     if $? != 0


### PR DESCRIPTION
In the version 6.0 of MongoDB, mongo shell is deprecated (no binary anymore). 
We need to replace it with mongosh in this boshrelease in order to prepare the next upgrade (5.x -> 6.x)