### PR TITLE
Set vm.max_map_count value of 102400

### DIFF
--- a/jobs/mms-automation-agent/templates/bin/mms-automation-agent_ctl
+++ b/jobs/mms-automation-agent/templates/bin/mms-automation-agent_ctl
@@ -35,6 +35,9 @@ case $1 in
         if [[ $(sysctl kernel.threads-max | awk '{print $3;}') -lt 64000 ]]; then
           sysctl -w kernel.threads-max=64000
         fi
+        if [[ $(sysctl vm.max_map_count | awk '{print $3;}') -lt 102400 ]]; then
+          sysctl -w vm.max_map_count=102400
+        fi
         sysctl -w net.ipv4.tcp_keepalive_time=120
     <% end %>
 


### PR DESCRIPTION
The purpose of this change is to be in line with mongodb recommendations:
https://www.mongodb.com/docs/v6.0/administration/production-checklist-operations/

See section including information about vm.max_map_count